### PR TITLE
Update 2019-03-15-a-lang-design-analysis-of-holyc.md

### DIFF
--- a/_posts/2019-03-15-a-lang-design-analysis-of-holyc.md
+++ b/_posts/2019-03-15-a-lang-design-analysis-of-holyc.md
@@ -97,7 +97,7 @@ I64 Sum(...)
 I64 x = Sum(3, 4, 5); // x = 12
 ```
 
-Note that `for` loops in _HolyC_ don't require curly braces if they only perform one operation.
+Note that `for` loops don't require curly braces if they only perform one operation. This is true in both C and HolyC.
 
 Finally, _HolyC_ does _not_ have a required `Main()` function. Expressions outside of functions are simply evaluated from top to bottom in source. This also allows the programming language to act like a shell, and in-fact _is_ the shell of TempleOS.
 
@@ -169,7 +169,7 @@ This is essentially _HolyC_'s solution to _macros_.
 
 # Misc Features & Quirks
 
-* In _HolyC_, you can `Free()` a null pointer.
+* In _HolyC_, you can `Free()` a null pointer (this is also true in C). 
 * The stack does not grow because _HolyC_ does not utilize virtual memory.
 * There is no `continue` keyword in the language. Instead, Terry urges programmers to use `goto`'s instead.
 * There is no `#define` capability. Terry's explanation for this is that he's just "not a fan".


### PR DESCRIPTION
Fixed two inaccurate statements as they are true in both C and HolyC.

Included is some screenshots of the constructs implied to only work in HolyC, working just fine in ISO C.

![image](https://user-images.githubusercontent.com/6936507/176983869-0c43f1e3-e682-41fd-b1f2-68100dad62b8.png)
![image](https://user-images.githubusercontent.com/6936507/176983871-86bd8ae0-1db3-4647-80bd-fc9a0d17c7ba.png)

Specifically regarding for loops, the formal syntax definition of a `for` statement is the keyword `for` followed by parentheses enclosing a declare or expression statement, followed by two expressions separated by a semicolon, followed by a statement as the body of the for loop. 

Here is the MSDN and the C standard itself describing it a bit more succinctly than I did:
![image](https://user-images.githubusercontent.com/6936507/176984246-cffd4433-dd45-4ecf-b2f7-fa5f2b5e11e2.png)
![image](https://user-images.githubusercontent.com/6936507/176984304-2625705a-dc03-4d27-9f20-92f7ad0e9576.png)

Here's a copy of ISO/IEC 9899:TC3 (it's a 2007 draft but is good enough for this discussion) if you want to read it for yourself: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf

The body of the for loop can be most types of statement with a couple notable exceptions, like declare statements. This for instance is invalid:

```c
for (int i = 0; i < 10; ++i)
    int j = i * 10; // invalid; you can't use a declare statement as the body of a control flow or label statement
```

And that's probably a good thing, since the `j` variable here would go out of scope once the for loop finishes, and therefore this snippet achieves nothing. But compound statements (zero or more statements enclosed in `{}`), null statements, expression statements, return statements and other control flow statements such as if, for, switch, etc. are all allowed.

```c
// compound or block statement
for (...)
    {
        ...
    }

// expression statement
for (...)
    puts("Hello");

// null or empty statement
for (...)
    ;

// return statement
for (...)
    return some_value;

// if statement + example usage
struct table_entry *
find_entry(int value)
{
    for (struct table_entry *selent = table; !selent->end; ++selent)
        if (selent->value == value)
            return selent;

    return NULL;
}

```

all of that is valid C89. I indented the brackets for emphasis.
